### PR TITLE
Link to Bukkit 1.7.10.

### DIFF
--- a/kTriggers.iml
+++ b/kTriggers.iml
@@ -5,17 +5,11 @@
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/main/resources" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/target/generated-sources/annotations" isTestSource="false" />
-      <excludeFolder url="file://$MODULE_DIR$/target/classes" />
-      <excludeFolder url="file://$MODULE_DIR$/target/maven-archiver" />
-      <excludeFolder url="file://$MODULE_DIR$/target/surefire" />
-      <excludeFolder url="file://$MODULE_DIR$/target/test-classes" />
+      <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
+      <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" name="Maven: org.bukkit:bukkit:1.2.3-R0.2-SNAPSHOT" level="project" />
+    <orderEntry type="library" name="Maven: org.bukkit:bukkit:1.7.10-R0.1-SNAPSHOT" level="project" />
   </component>
 </module>
-

--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,8 @@
             <url>http://repo.bukkit.org/content/groups/public</url>
         </repository>
         <repository>
-            <id>ks-releases</id>
-            <url>http://files.krinsoft.net:8085/nexus/content/groups/public</url>
+            <id>sk89q</id>
+            <url>http://maven.sk89q.com/repo</url>
         </repository>
     </repositories>
 
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
-            <version>1.2.5-R4.0</version>
+            <version>1.7.10-R0.1-SNAPSHOT</version>
             <type>jar</type>
         </dependency>
     </dependencies>

--- a/src/main/java/net/krinsoft/ktriggers/commands/kTriggerCommand.java
+++ b/src/main/java/net/krinsoft/ktriggers/commands/kTriggerCommand.java
@@ -101,7 +101,7 @@ public class kTriggerCommand implements Command {
         } else if (executeAs.equals("console")) {
             executors.add(plugin.getServer().getConsoleSender());
         } else if (executeAs.equals("everyone")) {
-            Collections.addAll(executors, plugin.getServer().getOnlinePlayers());
+            executors.addAll(plugin.getServer().getOnlinePlayers());
         } else {
             try {
                 int param = Integer.parseInt(executeAs.replaceAll("param([0-9]+)", "$1"));


### PR DESCRIPTION
Spigot 1.9 onwards removes the support for the deprecated version of `Server.getOnlinePlayers()`. This uses the non-deprecated version of `Server.getOnlinePlayers()` to correctly use the one that returns `Collection<? extends Player>` instead of `Player[]`.
